### PR TITLE
Larsoft v09 76 00 update + disambiguated hits for FD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules REQUIRED)
-project(webevd VERSION 09.75.00 LANGUAGES CXX)
+project(webevd VERSION 09.76.00 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -249,8 +249,8 @@ libdir	fq_dir		lib
 #
 ####################################
 product		version		qual	flags		<table_format=2>
-gallery		v1_18_05	-
-lardata		v09_13_02	-
+gallery		v1_20_02	-
+lardata		v09_15_01 -
 cetmodules	v3_20_00	-	only_for_build
 end_product_list
 ####################################

--- a/webevd/WebEVD/WebEVDServer.cxx
+++ b/webevd/WebEVD/WebEVDServer.cxx
@@ -651,17 +651,21 @@ namespace evd {
       // This can fail in the case of dropped products
       if (!evt.getByLabel(tag, hits)) continue;
 
-      for (const recob::Hit& hit : *hits) {
-        // Would possibly be right for disambiguated hits?
-        //    const geo::WireID wire(hit.WireID());
 
+      for (const recob::Hit& hit : *hits) {
+        // Hits with this label should be disambiguated
+        // NOTE This is only for DUNE FD, there will be other disambiguated hit products
+        // not treated this way
+        if (tag.label() == "hitfd") {
+          const geo::PlaneID plane(hit.WireID());
+          plane_hits[tag][plane].push_back(hit);
+          continue;
+        }
+
+        // These hits are not disambiguated so consider all possible wires
         for (geo::WireID wire : geom->ChannelToWire(hit.Channel())) {
           const geo::PlaneID plane(wire);
 
-          // Correct for disambiguated hits
-          //      plane_hits[plane].push_back(hit);
-
-          // Otherwise we have to update the wire number
           plane_hits[tag][plane].emplace_back(hit.Channel(),
                                               hit.StartTick(),
                                               hit.EndTick(),


### PR DESCRIPTION
1. Update dependencies for larsoft 09_76_00 + bump version. The 09_75_00 tag was not working with the corresponding larsoft version (which was my fault in the last PR).

2. I think hitfd is always the disambiguated hits label in the FD so treat the WireID correctly